### PR TITLE
Include auth information from EAS in entity object.

### DIFF
--- a/schema/EntityObject.md
+++ b/schema/EntityObject.md
@@ -5,13 +5,14 @@ The Entity Object, along with its validation on the KAS, provides a means to ens
 
 ## Version
 
-The current schema version is `1.0.0`.
+The current schema version is `1.1.0`.
 
 ## Example
 
 ```javascript
 {
   "userId": "user@virtru.com",
+  "auth": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
   "aliases": [],
   "attributes": [
     {
@@ -30,6 +31,7 @@ The current schema version is `1.0.0`.
 |Parameter|Type|Description|Required?|
 |---|---|---|---|
 |`userId`|String|A user id used to identify the user, such as email, that will be used to authenticate against the EAS.|Yes|
+|`auth`|Object|JWT containing arbitrary supplementary identifying information from the EAS's auth scheme. KAS can use this to auth internal and downstream operations.
 |`aliases`|Array|`aliases` are not yet implemented, but will provide further flexibility by assigning additional aliases to a user. This can remain empty for the time being.|Yes|
 |`attributes`|Array|An array of signed [Attribute Object](AttributeObject.md)s. At most one of these may be a _default_ AttributeObject.|Yes|
 |`attributes.jwt`|String|An [Attribute Object](AttributeObject.md) that has been signed with the EAS private key as a [JWT](https://jwt.io/).|Yes|


### PR DESCRIPTION
### Proposed Changes

* This change modifies the Entity Object to include identifying information derived by EAS from its auth scheme. The client can send this information to KAS in order to auth for its `upsert` and `rewrap` operations.
* The intent is to make the EO a true bearer token, instead of the client needing to re-auth with KAS. Since EAS is the auth authority in our architecture, the re-auth is redundant, onerous, and trust-breaking.

### Checklist

- [x] A clear description of the change has been included in this PR.
- [x] The changelog has been updated.
- [x] All schema validation tests have been updated appropriately and are passing.
- [x] Version numbers have been updated as per the [Versioning Guidelines](../CONTRIBUTING.md#verison-changes).
- [ ] Major/minor version changes only: A writeup has been included discussing the motivation and impact of this change.
- [ ] Major/minor version changes only: The minimum wait time has elapsed.
- [ ] Project version changes only: I have updated both the `VERSION` file and the `git tag`.
- [x] This change otherwise adheres to the project [Contribution Guidelines](../CONTRIBUTING.md).
- [x] Every item in this checklist has been completed.
