### PR TITLE
📝 PLAT-897 Allow separate signing and wrapper keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 ## Added
   * _patch_: ([#17](https://github.com/virtru/tdf3-spec/pull/17))
     Add KAS swagger 
+  * _patch_: ([#24](https://github.com/virtru/tdf3-spec/pull/24)), PLAT-897: `EntityObject.signerPublicKey`
+    - Add a second 'signerPublicKey' field to an EO
+    - This is an ephemeral public key a client may use to sign rewrap and other requests associated with the EO.
+    - This is required as some algorithms and key types are more suited for encryption and others for signatures. Notably, we must support this for the smaller keys and restricted set of algorithms that NanoTDF will likely impose
+    - Implementations:
+      - Client [nanotdf for javascript](https://github.com/virtru/eternia/pull/78)
+      - Client [c++](https://github.com/virtru/tdf3-cpp/pull/193)
+      - Service [OpenStack EAS and KAS (python)](https://github.com/virtru/etheria/pull/295)
+
 ## Changes
 * 1.3.4 (2019-08-05)
   * _patch_: ([#20](https://github.com/virtru/tdf3-spec/pull/20))

--- a/schema/EntityObject.md
+++ b/schema/EntityObject.md
@@ -40,10 +40,11 @@ When an entity wishes to decrypt a file, the following steps using the Entity Ob
 |`attributes`|Array|An array of signed [Attribute Object](AttributeObject.md)s. At most one of these may be a _default_ AttributeObject.|Yes|
 |`attributes.jwt`|String|An [Attribute Object](AttributeObject.md) that has been signed with the EAS private key as a [JWT](https://jwt.io/).|Yes|
 |`publicKey`|String|The entity's public key, in a PEM-encoded format.|Yes|
+|`signerPublicKey`|String|A second public key used for signing the KAS requests, in a PEM-encoded format.|Depends on Algorithm|
 |`cert`|String|The [Entity Object](EntityObject.md) contents (without `cert`) that has been signed with the EAS private key, as a [JWT](https://jwt.io/). The KAS uses this field to validate the authenticity of the Entity Object. |Yes|
 |`schemaVersion`|String|Version number of the Entity Object schema.|No|
 
 
 ## Version
 
-The current schema version is `1.1.0`.
+The current schema version is `1.1.1`.

--- a/schema/EntityObject.md
+++ b/schema/EntityObject.md
@@ -40,7 +40,7 @@ When an entity wishes to decrypt a file, the following steps using the Entity Ob
 |`attributes`|Array|An array of signed [Attribute Object](AttributeObject.md)s. At most one of these may be a _default_ AttributeObject.|Yes|
 |`attributes.jwt`|String|An [Attribute Object](AttributeObject.md) that has been signed with the EAS private key as a [JWT](https://jwt.io/).|Yes|
 |`publicKey`|String|The entity's public key, in a PEM-encoded format.|Yes|
-|`signerPublicKey`|String|A second public key used for signing KAS requests, in a PEM-encoded format. When using TDF3 with elliptic curve cryptography, for example, the public key may be an ECDH keypair and the signing key, an ECDSA component.|Optional, depends on choice of algorithm|
+|`signerPublicKey`|String|A second public key used for signing KAS requests, in a PEM-encoded format. When using TDF3 with elliptic curve cryptography, the public key may use ECDH and the signing key ECDSA.|Optional, depends on choice of algorithm|
 |`cert`|String|The [Entity Object](EntityObject.md) contents (without `cert`) that has been signed with the EAS private key, as a [JWT](https://jwt.io/). The KAS uses this field to validate the authenticity of the Entity Object. |Yes|
 |`schemaVersion`|String|Version number of the Entity Object schema.|No|
 

--- a/schema/EntityObject.md
+++ b/schema/EntityObject.md
@@ -40,7 +40,7 @@ When an entity wishes to decrypt a file, the following steps using the Entity Ob
 |`attributes`|Array|An array of signed [Attribute Object](AttributeObject.md)s. At most one of these may be a _default_ AttributeObject.|Yes|
 |`attributes.jwt`|String|An [Attribute Object](AttributeObject.md) that has been signed with the EAS private key as a [JWT](https://jwt.io/).|Yes|
 |`publicKey`|String|The entity's public key, in a PEM-encoded format.|Yes|
-|`signerPublicKey`|String|A second public key used for signing the KAS requests, in a PEM-encoded format.|Depends on Algorithm|
+|`signerPublicKey`|String|A second public key used for signing KAS requests, in a PEM-encoded format. When using TDF3 with elliptic curve cryptography, for example, the public key may be an ECDH keypair and the signing key, an ECDSA component.|Optional, depends on choice of algorithm|
 |`cert`|String|The [Entity Object](EntityObject.md) contents (without `cert`) that has been signed with the EAS private key, as a [JWT](https://jwt.io/). The KAS uses this field to validate the authenticity of the Entity Object. |Yes|
 |`schemaVersion`|String|Version number of the Entity Object schema.|No|
 


### PR DESCRIPTION
### Proposed Changes

#### PLAT-897

- Add a second 'signerPublicKey' field to an EO
- This is an ephemeral public key a client may use to sign rewrap and other requests associated with the EO.
- This is required as some algorithms and key types are more suited for encryption and others for signatures. Notably, we must support this for the smaller keys and restricted set of algorithms that NanoTDF will likely impose
- Implementation:
  - Client [nanotdf for javascript](https://github.com/virtru/eternia/pull/78)
  - Client [c++](https://github.com/virtru/tdf3-cpp/pull/193)
  - Service [OpenStack EAS and KAS (python)](https://github.com/virtru/etheria/pull/295)

### Checklist

- [x] A clear description of the change has been included in this PR.
- [x] The changelog has been updated.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] Version numbers have been updated as per the [Versioning Guidelines](../CONTRIBUTING.md#verison-changes).
- [ ] Major/minor version changes only: A writeup has been included discussing the motivation and impact of this change.
- [ ] Major/minor version changes only: The minimum wait time has elapsed.
- [ ] Project version changes only: I have updated both the `VERSION` file and the `git tag`.
- [ ] This change otherwise adheres to the project [Contribution Guidelines](../CONTRIBUTING.md).
- [ ] Every item in this checklist has been completed.
