### PR TITLE
Minor doc tweaks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 - [ ] A clear description of the change has been included in this PR.
 - [ ] Spec Semver version has been updated in the VERSION file
-- [ ] Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -a 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
+- [ ] Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
 - [ ] All schema validation tests have been updated appropriately and are passing.
 - [ ] Version numbers have been updated as per the [Versioning Guidelines](../CONTRIBUTING.md#verison-changes).
 - [ ] Major/minor version changes only: A writeup has been included discussing the motivation and impact of this change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,17 @@ The spec version is this repo's most recent semver Git tag - this means that if 
 
 Any changes that affect _project_ version must update both `git tag` and the [VERSION](VERSION) file.
 
-Rather than use a changelog, we ask that you use annotated `git tags` when bumping the spec Semver, and use the annotation message to describe the change.
-> Example: `git tag -a 4.1.0 -m "Spec version 4.1.0 - twiddled a doohickey"`)
+#### Tracking Versions
+Rather than use a CHANGELOG file, we ask that you use annotated `git tags` when bumping the spec Semver, and use the annotation message to describe the change.
+> Example: `git tag -s 4.1.0 -m "Spec version 4.1.0 - twiddled a doohickey"`)
+
+Please use the raw semver when tagging - no `v4.1.0`, just `4.1.0`
 
 A list of `git tag` versions and their annotations can be generated at will via `git tag -n`
+
+To create a CHANGELOG file, run the following command
+
+`git tag -n --sort=-v:refname > CHANGELOG`
 
 ## Asking Questions & Submitting Feeback
 


### PR DESCRIPTION
### Proposed Changes

* Update CONTRIBUTING.md and the PR template to use `-a` instead of `-s` in `git tag` commands - latter generates signed tags, which is what we want.

### Checklist

- [x] A clear description of the change has been included in this PR.
- [x] Spec Semver version has been updated in the VERSION file
- [x] Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -a 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [x] All schema validation tests have been updated appropriately and are passing.
- [x] Version numbers have been updated as per the [Versioning Guidelines](../CONTRIBUTING.md#verison-changes).
- [x] Major/minor version changes only: A writeup has been included discussing the motivation and impact of this change.
- [x] Major/minor version changes only: The minimum wait time has elapsed.
- [x] Project version changes only: I have updated both the `VERSION` file and the `git tag`.
- [x] This change otherwise adheres to the project [Contribution Guidelines](../CONTRIBUTING.md).
- [x] Every item in this checklist has been completed.
